### PR TITLE
Added support for non-indexed files

### DIFF
--- a/lovefs/lovefs.lua
+++ b/lovefs/lovefs.lua
@@ -156,7 +156,7 @@ function filesystem:ls(dir)
 				local fn = w2u(fd.cFileName)
 				if fd.dwFileWttributes == 16 or fd.dwFileWttributes == 17 or (self.showHidden and fd.dwFileWttributes == 8210) then
 					table.insert(tDirs, fn)
-				elseif fd.dwFileWttributes == 32 then
+				elseif fd.dwFileWttributes == 32 or fd.dwFileWttributes == 0x2020 then
 					table.insert(tFiles, fn)
 				end
 			until not ffi.C.FindNextFileW(hFile, fd)


### PR DESCRIPTION
When using lovefs I noticed some files are not being read. I tracked the problem down to unhandled file attributes. I added my unhandled file attribute 0x2020 to lovefs, and I'm now able to read the files. I can also add hidden file support if desired.

Some questions:

Wouldn't it be better to use hex codes (for clarity) for file attributes, as described in https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants or https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-tools/widl/include/winnt.h#L4513 ?

Also shouldn't the variable be called dwFileAttributes instead of dwFileWttributes?